### PR TITLE
Change search logic to prevent hiding samples

### DIFF
--- a/examples/microGranny2_5/fileNames.ino
+++ b/examples/microGranny2_5/fileNames.ino
@@ -1,5 +1,4 @@
 //#include <mozzi_rand.h>
-unsigned char searchIndex=1;
 
 void dt(){
   hw.displayText("SRCH");
@@ -17,20 +16,17 @@ void listNameUp(){
     hw.updateDisplay();
 //    hw.displayText("SRCH");
     dt();
-    name[1]+=searchIndex;
-    searchIndex++;
-    if(name[1]>=58 && name[1]<65) name[1]=65,searchIndex=1;
+    name[1]+=1;
+    if(name[1]>=58 && name[1]<65) name[1]=65;
     else if(name[1]>=91){
       name[1]=48; 
       upWithFirstLetter();
-      searchIndex=1;
     }
   }
   file.close();
   indexed(activeSound,false);
   if(!playBegin(name,activeSound)) listNameUp();
   stopSound();
-  searchIndex=1;
 
 }
 void listNameDown(){
@@ -47,14 +43,12 @@ void listNameDown(){
     hw.updateDisplay();
     dt();
    // hw.displayText("SRCH");
-    name[1]-=searchIndex;
-    searchIndex++;
+    name[1]-=1;
     if(name[1]<48){
       name[1]=90;
       downWithFirstLetter();
-      searchIndex=1;
     }
-    else if(name[1]<65 && name[1]>58) name[1]=58,searchIndex=1;
+    else if(name[1]<65 && name[1]>58) name[1]=58;
   }
   file.close();
   indexed(activeSound,false);
@@ -62,7 +56,6 @@ void listNameDown(){
   if(!playBegin(name,activeSound)) listNameDown();
 
   stopSound();
-  searchIndex=1;
 }
 
 void upWithFirstLetter(){


### PR DESCRIPTION
Incrementing searchIndex after not finding a file can result in samples becoming effectively hidden.
Minimal example: If you have samples 00, 06, and 12 (no samples between), sample 06 can't be found (listNameUp starting with 00 gives 12, listNameDown starting with 12 gives 00). You would need to record extra samples to fill in the search gaps in order for 06 to be found. This change increases search times (especially for bigger gaps), but ensures all samples can be found.